### PR TITLE
providing options for http requests

### DIFF
--- a/src/app/wish.service.ts
+++ b/src/app/wish.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { catchError } from 'rxjs/operators';
 import { throwError } from 'rxjs';
+import { WishItem } from '../shared/models/wishItems';
 
 @Injectable({
   providedIn: 'root'
@@ -13,12 +14,39 @@ export class WishService {
   // getWishes() {
   //   return this.http.get('assets/wishes.json');
   // }
+
+  private getStandardOptions() : any {
+    return {
+      headers: new HttpHeaders({
+        'Content-Type': 'application/json',
+      }),
+    };
+  }
+
+
   getWishes() {
-    return this.http.get('assets/wishes.json').pipe(
+    let options = this.getStandardOptions();
+
+    options.params = new HttpParams({
+      fromObject: {
+      format: 'json',
+    }
+    });
+
+    return this.http.get('assets/wishes.json', options).pipe(
       catchError(error => {
         console.error('Error fetching wishes:', error);
         return throwError(() => new Error('Failed to fetch wishes'));
       })
     );
+    
+  }
+
+  private addWish(wish: WishItem) {
+    let options = this.getStandardOptions();
+
+    options.headers = options.headers.set('Authorization', "value-needed-for-authorization");
+    this.http.post('assets/wishes.json', wish, options);
+    // this.http.post(url, body, options);
   }
 }


### PR DESCRIPTION
This pull request includes several enhancements to the `WishService` in the `src/app/wish.service.ts` file. The most important changes involve adding new imports, creating a method for standard HTTP options, and updating the `getWishes` method to use these options. Additionally, a new method for adding wishes has been introduced.

Enhancements to `WishService`:

* Added imports for `HttpHeaders`, `HttpParams`, and `WishItem` to support new functionality.
* Created a new method `getStandardOptions` to standardize HTTP options, including setting the `Content-Type` header to `application/json`.
* Updated the `getWishes` method to use the standardized HTTP options and added query parameters for the request.
* Introduced a new method `addWish` to post a new wish item, including setting an authorization header.