### PR TITLE
Section 6  lesson 4

### DIFF
--- a/src/app/contact/contact.component.html
+++ b/src/app/contact/contact.component.html
@@ -22,7 +22,9 @@
         <small class="text-danger" *ngIf="contactForm.get('email')?.hasError('required')">This field is required</small>
         <small class="text-danger" *ngIf="contactForm.get('email')?.hasError('email')">Please enter a valid email
           address.</small>
-
+        <small class="text-danger" *ngIf="contactForm.get('email')?.hasError('invalidEmailDomain')">'example.com',
+          'test.com', 'demo.com are not valid
+          email domains.</small>
       </div>
     </div>
     <div class="mb-3">

--- a/src/app/contact/contact.component.ts
+++ b/src/app/contact/contact.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { FormControl, ReactiveFormsModule, FormGroup, Validators } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-
+import { invalidEmailDomain } from './invalidEmailDomain';
 @Component({
   selector: 'app-contact',
   imports: [ReactiveFormsModule, CommonModule],
@@ -14,7 +14,7 @@ export class ContactComponent {
 
   contactForm = new FormGroup({
     name: new FormControl('', [Validators.required, Validators.minLength(3)]),
-    email: new FormControl('', [Validators.required, Validators.email]),
+    email: new FormControl('', [Validators.required, Validators.email, invalidEmailDomain]),
     message: new FormControl('', [Validators.required, Validators.minLength(10)])
   });
 

--- a/src/app/contact/contact.component.ts
+++ b/src/app/contact/contact.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
 import { FormControl, ReactiveFormsModule, FormGroup, Validators } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { invalidEmailDomain } from './invalidEmailDomain';
+import { createInvalidDomainValidator } from './invalidEmailDomain';
+
+const invalidEmailDomain = createInvalidDomainValidator(['example.com', 'test.com', 'demo.com']);
+
 @Component({
   selector: 'app-contact',
   imports: [ReactiveFormsModule, CommonModule],

--- a/src/app/contact/invalidEmailDomain.ts
+++ b/src/app/contact/invalidEmailDomain.ts
@@ -1,0 +1,13 @@
+import { AbstractControl, ValidationErrors } from "@angular/forms";
+
+export function invalidEmailDomain(control: AbstractControl) : ValidationErrors | null {
+  const value = control.value?.toLowerCase();
+  const hosts = ['example.com', 'test.com', 'demo.com'];
+  if (!value || typeof value !== 'string') {
+    return null; // No validation error if value is empty or not a string
+  }
+
+  const matches = hosts.some(host => value.indexOf(`@${host}`) > -1);
+
+  return matches ? { invalidEmailDomain : true } : null; // Return error if domain matches, otherwise return null
+}

--- a/src/app/contact/invalidEmailDomain.ts
+++ b/src/app/contact/invalidEmailDomain.ts
@@ -1,13 +1,14 @@
-import { AbstractControl, ValidationErrors } from "@angular/forms";
+import { AbstractControl, ValidationErrors, ValidatorFn } from "@angular/forms";
 
-export function invalidEmailDomain(control: AbstractControl) : ValidationErrors | null {
-  const value = control.value?.toLowerCase();
-  const hosts = ['example.com', 'test.com', 'demo.com'];
-  if (!value || typeof value !== 'string') {
-    return null; // No validation error if value is empty or not a string
+export function createInvalidDomainValidator(hosts: string[]) : ValidatorFn {
+  return (control: AbstractControl) : ValidationErrors | null => {
+    const value = control.value?.toLowerCase();
+    if (!value || typeof value !== 'string') {
+      return null; // No validation error if value is empty or not a string
+    }
+  
+    const matches = hosts.some(host => value.indexOf(`@${host}`) > -1);
+  
+    return matches ? { invalidEmailDomain : true } : null; // Return error if domain matches, otherwise return null
   }
-
-  const matches = hosts.some(host => value.indexOf(`@${host}`) > -1);
-
-  return matches ? { invalidEmailDomain : true } : null; // Return error if domain matches, otherwise return null
 }


### PR DESCRIPTION
This pull request enhances email validation in the contact form by introducing a custom validator to restrict specific email domains. The changes ensure that users cannot submit emails from disallowed domains such as `example.com`, `test.com`, and `demo.com`.

### Email Validation Enhancements:

* **Custom Validator Implementation**:
  - Added a new file `src/app/contact/invalidEmailDomain.ts` to define the `createInvalidDomainValidator` function, which checks if an email's domain matches any in a restricted list.

* **Integration with Contact Form**:
  - Updated `src/app/contact/contact.component.ts` to import the custom validator and apply it to the `email` field in the `contactForm`. [[1]](diffhunk://#diff-3a86ca955eaaddd09cee317164dce0c475e7650f1f5e823e6db211e12ef33b7aR4-R6) [[2]](diffhunk://#diff-3a86ca955eaaddd09cee317164dce0c475e7650f1f5e823e6db211e12ef33b7aL17-R20)

* **User Feedback**:
  - Modified `src/app/contact/contact.component.html` to display an error message when the `email` field contains a restricted domain.